### PR TITLE
Add first skill card audit batch

### DIFF
--- a/docs/reports/skill-card-audit-ledger.md
+++ b/docs/reports/skill-card-audit-ledger.md
@@ -1,0 +1,38 @@
+# Skill Card Audit Ledger
+
+This ledger tracks manual and automated skill-card audit batches. Keep entries append-only after merge so future automation runs can select the next unchecked cards from `cards.json` without re-auditing recent fixes.
+
+## Batch 1 - 2026-07-03
+
+Branch: `skill-card-audit-batch-1`
+Base: `origin/main` at `24380f2` (`Deploy: Add Tomari Live Start prompt regression`)
+Scope: first manual run, up to 3 representative skill cards. Recent manual fixes for Tomari and Rurino were intentionally avoided.
+
+### Cards Checked
+
+| Card | Card No. | Skill Surface | Audit Result | Evidence |
+| --- | --- | --- | --- | --- |
+| Ai Scream! | `LL-PR-004-PR` | `[Live Start]` opponent text answer; branches into both discard, both draw, or both-stage Blade modifier. | Works; no code fix needed. | `scripts/audit_card_interactions.mjs` reports exact server ability coverage; `SkillCardAuditBatch1Test::testAiScreamLiveStartOpponentTextAnswerAppliesBothStageBladeBonus` verifies prompt creation, opponent resolution, Live Start continuation, and both-stage Blade modifier application. |
+| Rin Hoshizora | `PL!-PR-005-PR` | `[On Enter]` `player_choice`; draw/discard branch or wait all opponent cost <=2 Stage Members. | Works; no code fix needed. | Static audit covers `player_choice`, `draw_and_discard`, and `wait_opponent_stage_max_cost`; `SkillCardAuditBatch1Test::testRinPlayerChoiceCanWaitAllOpponentLowCostMembers` verifies the menu and low-cost opponent Stage wait resolution while preserving higher-cost Members. |
+| Nico Yazawa | `PL!-PR-009-PR` | `[On Enter] / [Live Start]` optional self-wait to wait one opponent cost <=4 Stage Member. | Works; no code fix needed. | Static audit covers `optional_wait_self_wait_opp`; `SkillCardAuditBatch1Test::testNicoLiveStartOptionalWaitSelfWaitsOneOpponentMember` verifies Live Start prompt creation, optional yes path, self-wait, opponent wait, and Live Start phase recovery. |
+
+### Blocked Items
+
+None for this batch.
+
+### Existing Warnings
+
+`node scripts/audit_card_interactions.mjs` reports full exact server ability coverage (`581/581`) and no missing server routes. It also reports existing prompt UI coverage gaps not introduced by this batch: 68 server prompt types missing a client renderer branch, 64 server prompt types missing an exact CPU branch, 0 no-generic CPU risks, 11 client prompt orphans, and 41 CPU prompt orphans.
+
+### Validation
+
+- `node scripts/audit_card_interactions.mjs` - passed static server ability coverage; existing prompt renderer/CPU branch warnings recorded above.
+- `php scripts/validate_json.php` - passed.
+- `php scripts/validate_cards.php` - passed with 815 existing unknown-ability warnings.
+- `php -l tests/Engine/SkillCardAuditBatch1Test.php` - passed.
+- `php -l effects.php` - passed.
+- Focused PHP stdin smoke for the three audited cards - passed. This exercised the same resolver paths as the new PHPUnit coverage because local Composer/PHPUnit dependencies were unavailable.
+- `vendor/bin/phpunit --filter SkillCardAuditBatch1Test` - blocked: `vendor/bin/phpunit` not present in the isolated worktree.
+- `phpunit --version` and `composer --version` - blocked: neither executable is on PATH in this environment.
+- `bash scripts/lint_php.sh` - blocked under the default bash due CRLF handling (`set: pipefail\r: invalid option name`); rerun with Git Bash below.
+- `C:/Program Files/Git/bin/bash.exe -lc "cd ... && bash scripts/lint_php.sh"` - passed (`PHP syntax OK`).

--- a/tests/Engine/SkillCardAuditBatch1Test.php
+++ b/tests/Engine/SkillCardAuditBatch1Test.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLTCG\Tests\Engine;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkillCardAuditBatch1Test extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['TUT_PERF_MANUAL_PHASES'] = true;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TUT_PERF_MANUAL_PHASES']);
+    }
+
+    private function cardByNo(string $cardNo, string $instanceId): array
+    {
+        $data = json_decode((string)file_get_contents((string)constant('CARDS_FILE')), true);
+        $this->assertIsArray($data);
+
+        foreach ($data['cards'] ?? [] as $card) {
+            if (($card['card_no'] ?? '') === $cardNo) {
+                $card['instance_id'] = $instanceId;
+                $card['active'] = true;
+                return $card;
+            }
+        }
+
+        $this->fail('Missing test card ' . $cardNo);
+    }
+
+    private function baseState(string $phase = 'main_first'): array
+    {
+        return [
+            'phase' => $phase,
+            'seq' => 1,
+            'turn' => 1,
+            'first_player' => 'p1',
+            'active_player' => 'p1',
+            'live_attempt' => ['p1'],
+            'log' => [],
+            'players' => [
+                'p1' => [
+                    'id' => 'p1',
+                    'name' => 'Audit P1',
+                    'stage' => ['left' => null, 'center' => null, 'right' => null],
+                    'hand' => [],
+                    'waiting_room' => [],
+                    'live_zone' => [],
+                    'main_deck' => [],
+                    'energy_zone' => [],
+                    'success_lives' => [],
+                ],
+                'p2' => [
+                    'id' => 'p2',
+                    'name' => 'Audit P2',
+                    'stage' => ['left' => null, 'center' => null, 'right' => null],
+                    'hand' => [],
+                    'waiting_room' => [],
+                    'live_zone' => [],
+                    'main_deck' => [],
+                    'energy_zone' => [],
+                    'success_lives' => [],
+                ],
+            ],
+        ];
+    }
+
+    public function testAiScreamLiveStartOpponentTextAnswerAppliesBothStageBladeBonus(): void
+    {
+        $aiScream = $this->cardByNo('LL-PR-004-PR', 'audit_ai_scream');
+        $state = $this->baseState('live_start_effects');
+        $state['players']['p1']['live_zone'] = [$aiScream];
+        $state['live_start_optional_queue'] = [];
+
+        $state = \resolveLiveStartAbilities($state, 'p1');
+
+        $this->assertSame('opponent_text_answer', $state['pending_prompt']['type'] ?? null);
+        $this->assertSame('p2', $state['pending_prompt']['responder'] ?? null);
+        $this->assertSame('What do you like?', $state['pending_prompt']['prompt'] ?? null);
+
+        $state = \actionResolvePrompt($state, 'p2', ['answer_text' => 'ramen']);
+
+        $this->assertNull($state['pending_prompt'] ?? null);
+        $this->assertSame(1, \getBothStagesBladeBonus($state));
+        $this->assertSame('live_start_effects', $state['phase'] ?? null);
+    }
+
+    public function testRinPlayerChoiceCanWaitAllOpponentLowCostMembers(): void
+    {
+        $rin = $this->cardByNo('PL!-PR-005-PR', 'audit_rin');
+        $lowLeft = $this->cardByNo('PL!SP-sd1-020-SD', 'audit_low_left');
+        $lowCenter = $this->cardByNo('PL!SP-sd1-019-SD', 'audit_low_center');
+        $highRight = $this->cardByNo('PL!-PR-005-PR', 'audit_high_right');
+
+        $state = $this->baseState();
+        $state['players']['p1']['stage']['center'] = $rin;
+        $state['players']['p2']['stage'] = [
+            'left' => $lowLeft,
+            'center' => $lowCenter,
+            'right' => $highRight,
+        ];
+
+        $state = \resolveOnEnterAbilities($state, 'p1', $rin, 'center');
+
+        $this->assertSame('player_choice', $state['pending_prompt']['type'] ?? null);
+        $this->assertContains('wait_low', $state['pending_prompt']['choices'] ?? []);
+
+        $state = \actionResolvePrompt($state, 'p1', ['choice' => 'wait_low']);
+
+        $this->assertNull($state['pending_prompt'] ?? null);
+        $this->assertFalse($state['players']['p2']['stage']['left']['active'] ?? true);
+        $this->assertFalse($state['players']['p2']['stage']['center']['active'] ?? true);
+        $this->assertTrue($state['players']['p2']['stage']['right']['active'] ?? false);
+    }
+
+    public function testNicoLiveStartOptionalWaitSelfWaitsOneOpponentMember(): void
+    {
+        $nico = $this->cardByNo('PL!-PR-009-PR', 'audit_nico');
+        $oppLow = $this->cardByNo('PL!SP-sd1-020-SD', 'audit_opp_low');
+        $oppHigh = $this->cardByNo('PL!-PR-005-PR', 'audit_opp_high');
+
+        $state = $this->baseState('live_start_effects');
+        $state['players']['p1']['stage']['center'] = $nico;
+        $state['players']['p2']['stage'] = [
+            'left' => $oppLow,
+            'center' => $oppHigh,
+            'right' => null,
+        ];
+        $state['live_start_optional_queue'] = [];
+
+        $state = \resolveLiveStartAbilities($state, 'p1');
+
+        $this->assertSame('optional_wait_self', $state['pending_prompt']['type'] ?? null);
+        $this->assertSame('audit_nico', $state['pending_prompt']['source_id'] ?? null);
+
+        $state = \actionResolvePrompt($state, 'p1', ['choice' => 'yes']);
+
+        $this->assertNull($state['pending_prompt'] ?? null);
+        $this->assertFalse($state['players']['p1']['stage']['center']['active'] ?? true);
+        $this->assertFalse($state['players']['p2']['stage']['left']['active'] ?? true);
+        $this->assertTrue($state['players']['p2']['stage']['center']['active'] ?? false);
+        $this->assertSame('live_start_effects', $state['phase'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- Add the first committed skill-card audit ledger under docs/reports for automation continuity.
- Audit LL-PR-004-PR Ai Scream!, PL!-PR-005-PR Rin Hoshizora, and PL!-PR-009-PR Nico Yazawa against current resolver behavior.
- Add focused engine regression coverage for their prompt, Live Start, and opponent-stage wait paths.

## Test plan
- node scripts/audit_card_interactions.mjs
- php scripts/validate_json.php
- php scripts/validate_cards.php (passes with existing warnings)
- php -l tests/Engine/SkillCardAuditBatch1Test.php
- php -l effects.php
- Focused PHP stdin smoke for the three audited cards
- Git Bash: bash scripts/lint_php.sh

## Warnings
- Local Composer/PHPUnit are unavailable, so vendor/bin/phpunit --filter SkillCardAuditBatch1Test could not run in this worktree.
- validate_cards.php still reports existing unknown-ability warnings; none are introduced by this branch.

## Deploy instructions
No Hostinger deploy before PR acceptance/merge. This branch only adds docs and test coverage.

Made with [Cursor](https://cursor.com)