### PR TITLE
Hide skill-reveal popup from the revealing player

### DIFF
--- a/client/js/prompt-renderer.js
+++ b/client/js/prompt-renderer.js
@@ -2232,8 +2232,26 @@ global.renderPromptDiscardHandBranch = function renderPromptDiscardHandBranch(s,
   });
 };
 
+function skillRevealViewerId(myId) {
+  const g = global.G;
+  return myId || g?.playerId || g?.gameState?.my_id || null;
+}
+
+/**
+ * Public Reveal popup is opponent-only (spectators still see it).
+ * The revealing player already saw the cards in the look/hand prompt and the log.
+ */
+function shouldShowPublicSkillRevealPopup(rev, myId) {
+  if (!rev?.cards?.length) return false;
+  if (global.G?.isSpectator) return true;
+  const viewer = skillRevealViewerId(myId);
+  if (rev.pid && viewer && String(rev.pid) === String(viewer)) return false;
+  return true;
+}
+global.shouldShowPublicSkillRevealPopup = shouldShowPublicSkillRevealPopup;
+
 global.showPublicSkillRevealOverlay = function showPublicSkillRevealOverlay(rev, myId){
-  if (!rev?.cards?.length) return;
+  if (!shouldShowPublicSkillRevealPopup(rev, myId)) return;
   const ovl = el('overlay-skill-reveal');
   const grid = el('skill-reveal-grid');
   const ttl = el('skill-reveal-ttl');
@@ -2277,10 +2295,6 @@ global.showPublicSkillRevealFromState = function showPublicSkillRevealFromState(
   G._lastSkillRevealKey = key;
   G._shownSkillRevealKeys.add(key);
   G._shownSkillRevealKeys.add(idKey);
-  // Revealer already sees the cards (hand / look pile) and the log. Popup is for the opponent.
-  if (!G.isSpectator && rev.pid && myId && rev.pid === myId) {
-    return;
-  }
   showPublicSkillRevealOverlay(rev, myId);
 };
 

--- a/index.html
+++ b/index.html
@@ -2884,7 +2884,7 @@ if (/[?&]debug(?:=|&|$)/.test(location.search)) {
 <script src="client/js/state-apply.js?v=70"></script>
 <script src="client/js/stamps.js?v=21"></script>
 <script src="client/js/replay-debug.js?v=8"></script>
-<script src="client/js/prompt-renderer.js?v=94"></script>
+<script src="client/js/prompt-renderer.js?v=95"></script>
 <script src="client/js/tutorial-interactive.js?v=25"></script>
 <!-- Early auth guard: separate script so a main-bundle parse error cannot leave auth stuck forever. -->
 <script>
@@ -21394,6 +21394,8 @@ async function playHandSkillRevealSpec(spec, finalState, myId, delayMs = 0) {
     || (typeof enrichCard === 'function' ? enrichCard(spec.card) : null);
   if (!card) return;
   if (delayMs > 0) await sleep(delayMs);
+  // Popup is opponent-only; showPublicSkillRevealOverlay no-ops for the revealing player
+  // (look-reveal skills such as 4-cost Izumi still fly the card into hand below).
   if (typeof showPublicSkillRevealOverlay === 'function' && spec.card) {
     showPublicSkillRevealOverlay({
       pid: spec.pid,

--- a/tests/Engine/SkillRevealPublicTest.php
+++ b/tests/Engine/SkillRevealPublicTest.php
@@ -90,6 +90,8 @@ final class SkillRevealPublicTest extends TestCase
 
         $oppView = \filterStateForPlayer($state, 'p2-token');
         $this->assertContains('rev_live', array_column($oppView['skill_reveals']['cards'] ?? [], 'instance_id'));
+        $this->assertSame('p1', $state['skill_reveals']['pid'] ?? null);
+        $this->assertSame('p1', $oppView['skill_reveals']['pid'] ?? null);
         $log = implode("\n", array_map(
             static fn($e) => is_array($e) ? (string)($e['msg'] ?? '') : (string)$e,
             $oppView['log'] ?? []
@@ -98,6 +100,24 @@ final class SkillRevealPublicTest extends TestCase
         $this->assertStringContainsString('revealed', $log);
         $handIds = array_column($state['players']['p1']['hand'] ?? [], 'instance_id');
         $this->assertContains('rev_live', $handIds);
+
+        $revealAnims = [];
+        foreach ($state['log'] ?? [] as $entry) {
+            if (!is_array($entry) || empty($entry['anim']) || !is_array($entry['anim'])) {
+                continue;
+            }
+            foreach ($entry['anim'] as $anim) {
+                if (!empty($anim['reveal'])) {
+                    $revealAnims[] = $anim;
+                }
+            }
+        }
+        $this->assertNotEmpty($revealAnims);
+        $this->assertSame('p1', $revealAnims[0]['pid'] ?? null);
+        $this->assertSame(
+            'rev_live',
+            $revealAnims[0]['card']['instance_id'] ?? $revealAnims[0]['iid'] ?? null
+        );
     }
 
     public function testSkillRevealClearedOnNewTurn(): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Public **Reveal** skills (confirmed with 4-cost Izumi Katsuragi: look at the top 5, reveal a cost-9+ Hasunosora Member) still opened the revealed-card overlay for the player who just picked the card.

That overlay should only appear for the **opponent** (and spectators). The revealing player already saw the cards in the look/hand prompt and the log.

A previous change skipped the popup in the state-driven path (`showPublicSkillRevealFromState`), but look-reveal still queued a `reveal` animation. `playHandSkillRevealSpec` opened `overlay-skill-reveal` for **both** seats.

## Fix

- Gate the overlay at `showPublicSkillRevealOverlay` so every caller (state apply **and** the fly/reveal animation) skips the revealing player.
- Spectators still see the popup.
- The revealing player still gets the card-to-hand fly/flip; only the modal is suppressed.
- Engine test now asserts look-reveal publishes `skill_reveals.pid` plus a `reveal` anim tagged with the revealer’s seat (the contract the client uses).

## Verification

- `phpunit tests/Engine/SkillRevealPublicTest.php` — 4 tests, 20 assertions, OK
- Node extraction check of `shouldShowPublicSkillRevealPopup`: revealer skip, opponent show, spectator show
- Could not exercise a live PvP Izumi look-reveal in the browser here; the animation path was the remaining caller that ignored the older skip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

