### PR TITLE
Fix portrait mid-bar height consistency across phones

### DIFF
--- a/client/css/portrait.css
+++ b/client/css/portrait.css
@@ -1,7 +1,8 @@
 /**
  * Portrait play layout — gated by html.tcg-portrait-play
  * (Android Capacitor, ?play=portrait, or touch-web portrait auto).
- * Size modifiers: .tcg-portrait-phone | .tcg-portrait-square | .tcg-portrait-tablet
+ * Size modifiers: .tcg-portrait-phone | .tcg-portrait-phone-sm | .tcg-portrait-square | .tcg-portrait-tablet
+ * --p-ui-scale (unitless, set by tcgPortraitUiScale) shrinks fixed-px HUD chrome on small phones.
  */
 
 /* ── Safe areas & base shell ── */
@@ -1227,10 +1228,22 @@ html.tcg-portrait-play{
   --opp-hand-card-h: calc(var(--p-card-h) * 0.92);
   --p-board-max-w: 100%;
   --p-field-min: 110px;
+  /* Unitless density (1 = ~390×844). JS sets this for phones; default 1. */
+  --p-ui-scale: 1;
   /* Fixed CSS-px HUD height so phones with full hearts match empty-board
-     phones — never let mid-bar grow toward a large vh fraction. */
-  --p-hud-h: 100px;
+     phones — never let mid-bar grow toward a large vh fraction. Scaled down
+     on smaller CSS viewports via --p-ui-scale. */
+  --p-hud-action: calc(34px * var(--p-ui-scale, 1));
+  --p-hud-hearts: calc(18px * var(--p-ui-scale, 1));
+  --p-hud-h: calc(100px * var(--p-ui-scale, 1));
   --p-hud-max: var(--p-hud-h);
+}
+
+/* Discrete compact rail for clearly-small phones (ui-scale < 0.95). */
+html.tcg-portrait-play.tcg-portrait-phone-sm{
+  --p-field-min: 96px;
+  --p-stage-outline-scale: 0.58;
+  --p-live-outline-scale: 0.76;
 }
 
 /* Square foldables: reclaim vertical space so both fields stay playable. */
@@ -1240,6 +1253,9 @@ html.tcg-portrait-play.tcg-portrait-square{
   --p-hand-mine: calc(var(--p-card-h) * 0.50);
   --p-hand-opp: calc(var(--p-card-h) * 0.40);
   --p-field-min: 96px;
+  --p-ui-scale: 1;
+  --p-hud-action: 34px;
+  --p-hud-hearts: 18px;
   --p-hud-h: 96px;
   --p-hud-max: var(--p-hud-h);
   --p-stage-outline-scale: 0.58;
@@ -1254,6 +1270,9 @@ html.tcg-portrait-play.tcg-portrait-tablet{
   --p-hand-mine: calc(var(--p-card-h) * 0.54);
   --p-hand-opp: calc(var(--p-card-h) * 0.48);
   --p-field-min: 160px;
+  --p-ui-scale: 1;
+  --p-hud-action: 34px;
+  --p-hud-hearts: 18px;
   --p-hud-h: 108px;
   --p-hud-max: var(--p-hud-h);
   --p-stage-outline-scale: 1;
@@ -1861,10 +1880,10 @@ html.tcg-portrait-play .pb-hud{
   display:flex;
   flex-direction:column;
   justify-content:flex-start;
-  gap:2px;
+  gap:calc(2px * var(--p-ui-scale, 1));
   position:relative;
   /* Corner names are absolute — keep padding tight so HUD height stays fixed. */
-  padding:10px 6px 8px;
+  padding:calc(10px * var(--p-ui-scale, 1)) 6px calc(8px * var(--p-ui-scale, 1));
   margin:0;
   background: rgba(8, 14, 28, .94);
   border: 1px solid rgba(186,228,255,.22);
@@ -1880,8 +1899,8 @@ html.tcg-portrait-play .pb-wins-row{
   width:100%;
   min-width:0;
   flex:0 0 auto;
-  min-height:22px;
-  max-height:24px;
+  min-height:calc(22px * var(--p-ui-scale, 1));
+  max-height:calc(24px * var(--p-ui-scale, 1));
 }
 html.tcg-portrait-play .pb-side{
   display:flex;
@@ -1931,7 +1950,7 @@ html.tcg-portrait-play .pb-name-host h3,
 html.tcg-portrait-play .pb-name-host #my-name,
 html.tcg-portrait-play .pb-name-host #opp-name{
   margin:0;
-  font-size:11px;
+  font-size:calc(11px * var(--p-ui-scale, 1));
   font-weight:900;
   letter-spacing:.06em;
   text-transform:uppercase;
@@ -1957,12 +1976,12 @@ html.tcg-portrait-play .pb-nrg{
   display:inline-flex;
   align-items:center;
   gap:3px;
-  min-height:22px;
-  padding:2px 6px;
+  min-height:calc(22px * var(--p-ui-scale, 1));
+  padding:calc(2px * var(--p-ui-scale, 1)) calc(6px * var(--p-ui-scale, 1));
   border-radius:5px;
   background: rgba(20, 28, 48, .95);
   border: 1px solid rgba(186,228,255,.22);
-  font-size:11px;
+  font-size:calc(11px * var(--p-ui-scale, 1));
   font-weight:800;
   color:#ffe08a;
   max-width:100%;
@@ -1983,16 +2002,22 @@ html.tcg-portrait-play .pb-nrg .cpill{
   min-width:0;
   white-space:nowrap;
 }
-html.tcg-portrait-play .pb-nrg .pill-ico{ width:12px; height:12px; }
-html.tcg-portrait-play .pb-nrg b{ color:#ffe08a; font-size:12px; }
+html.tcg-portrait-play .pb-nrg .pill-ico{
+  width:calc(12px * var(--p-ui-scale, 1));
+  height:calc(12px * var(--p-ui-scale, 1));
+}
+html.tcg-portrait-play .pb-nrg b{
+  color:#ffe08a;
+  font-size:calc(12px * var(--p-ui-scale, 1));
+}
 html.tcg-portrait-play .pb-win-val{
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  min-width:38px;
-  padding:3px 7px;
+  min-width:calc(38px * var(--p-ui-scale, 1));
+  padding:calc(3px * var(--p-ui-scale, 1)) calc(7px * var(--p-ui-scale, 1));
   border-radius:5px;
-  font-size:13px;
+  font-size:calc(13px * var(--p-ui-scale, 1));
   font-weight:900;
   color:#b8ffc8;
   background: #1a3d28;
@@ -2016,9 +2041,9 @@ html.tcg-portrait-play .pb-hud .phase-panel{
 }
 html.tcg-portrait-play .pb-hud .phase-panel-head{ display:flex; align-items:center; gap:6px; }
 html.tcg-portrait-play .pb-hud .pbadge{
-  font-size:11px;
-  padding:3px 10px;
-  min-height:22px;
+  font-size:calc(11px * var(--p-ui-scale, 1));
+  padding:calc(3px * var(--p-ui-scale, 1)) calc(10px * var(--p-ui-scale, 1));
+  min-height:calc(22px * var(--p-ui-scale, 1));
 }
 html.tcg-portrait-play .pb-hud .pmsg,
 html.tcg-portrait-play .pb-hud .spectator-count,
@@ -2050,7 +2075,7 @@ html.tcg-portrait-play .pb-hud .stage-board-panel{
   border:none;
   flex:0 0 auto;
   min-height:0;
-  max-height:18px;
+  max-height:var(--p-hud-hearts, 18px);
   overflow:hidden;
 }
 html.tcg-portrait-play .pb-hud .stage-board-panel > h4{ display:none; }
@@ -2060,7 +2085,7 @@ html.tcg-portrait-play .pb-hud .stage-board-grid{
   gap:4px 6px;
   align-items:center;
   min-height:0;
-  height:18px;
+  height:var(--p-hud-hearts, 18px);
 }
 html.tcg-portrait-play .pb-hud .stage-board-side-lbl{ display:none; }
 html.tcg-portrait-play .pb-hud .stage-board-side{
@@ -2070,7 +2095,7 @@ html.tcg-portrait-play .pb-hud .stage-board-side{
   gap:4px;
   min-width:0;
   min-height:0;
-  max-height:18px;
+  max-height:var(--p-hud-hearts, 18px);
   overflow:hidden;
 }
 html.tcg-portrait-play .pb-hud .stage-board-side.mine{
@@ -2083,7 +2108,7 @@ html.tcg-portrait-play .pb-hud .stage-board-side.opp{
 }
 html.tcg-portrait-play .pb-hud .stage-board-hearts{
   min-height:0;
-  max-height:18px;
+  max-height:var(--p-hud-hearts, 18px);
   display:flex;
   flex-wrap:nowrap;
   align-items:center;
@@ -2118,7 +2143,7 @@ html.tcg-portrait-play .pb-hud .stage-board-hearts .heart-stat-row{
   display:inline-flex;
   align-items:center;
   gap:2px;
-  font-size:10px!important;
+  font-size:calc(10px * var(--p-ui-scale, 1))!important;
   font-weight:800;
   line-height:1;
   flex:0 0 auto;
@@ -2126,31 +2151,31 @@ html.tcg-portrait-play .pb-hud .stage-board-hearts .heart-stat-row{
 }
 html.tcg-portrait-play .pb-hud .stage-board-hearts .heart-stat-count,
 html.tcg-portrait-play .pb-hud .stage-board-hearts .stat-mod-bonus{
-  font-size:10px!important;
+  font-size:calc(10px * var(--p-ui-scale, 1))!important;
   line-height:1!important;
 }
 html.tcg-portrait-play .pb-hud .stage-board-hearts img,
 html.tcg-portrait-play .pb-hud .stage-board-hearts .ticon,
 html.tcg-portrait-play .pb-hud .stage-board-hearts .hicon{
-  width:12px!important;
-  height:12px!important;
+  width:calc(12px * var(--p-ui-scale, 1))!important;
+  height:calc(12px * var(--p-ui-scale, 1))!important;
 }
 html.tcg-portrait-play .pb-hud .stage-board-yell{
   display:flex;
   align-items:center;
   gap:3px;
-  font-size:10px;
+  font-size:calc(10px * var(--p-ui-scale, 1));
   line-height:1;
   opacity:.85;
   width:auto;
   flex:0 0 auto;
   white-space:nowrap;
-  max-height:18px;
+  max-height:var(--p-hud-hearts, 18px);
   overflow:hidden;
 }
 html.tcg-portrait-play .pb-hud .stage-board-yell .bicon{
-  width:12px!important;
-  height:12px!important;
+  width:calc(12px * var(--p-ui-scale, 1))!important;
+  height:calc(12px * var(--p-ui-scale, 1))!important;
 }
 html.tcg-portrait-play .pb-hud .stage-board-active,
 html.tcg-portrait-play .pb-hud .stage-board-abilities{ display:none!important; }
@@ -2164,10 +2189,10 @@ html.tcg-portrait-play .pb-phase-row{
   padding:0;
   position:relative;
   z-index:12;
-  flex:0 0 34px;
-  min-height:34px;
-  height:34px;
-  max-height:34px;
+  flex:0 0 var(--p-hud-action, 34px);
+  min-height:var(--p-hud-action, 34px);
+  height:var(--p-hud-action, 34px);
+  max-height:var(--p-hud-action, 34px);
 }
 html.tcg-portrait-play .pb-hud.pb-menu-open .pb-phase-row,
 html.tcg-portrait-play .pb-hud:has(.pb-menu-pop:not([hidden])) .pb-phase-row{
@@ -2204,12 +2229,12 @@ html.tcg-portrait-play .pb-phase-actions:has(.phase-action-bar[hidden]) .pb-menu
   transform:translateX(-50%);
 }
 html.tcg-portrait-play .pb-hud .btn-phase-primary{
-  min-height:34px;
+  min-height:var(--p-hud-action, 34px);
   width:100%;
   max-width:none;
-  font-size:13px;
+  font-size:calc(13px * var(--p-ui-scale, 1));
   border-radius:10px;
-  padding:6px 12px;
+  padding:calc(6px * var(--p-ui-scale, 1)) calc(12px * var(--p-ui-scale, 1));
 }
 /* Phase timer sits between End Main and the burger when enabled. */
 html.tcg-portrait-play .pb-phase-actions > .phase-timer-wrap{
@@ -2232,12 +2257,12 @@ html.tcg-portrait-play .pb-phase-actions > .phase-timer-wrap.phase-timer-wrap--p
   z-index:1;
 }
 html.tcg-portrait-play .pb-phase-actions .time-pie.phase-timer-pie{
-  width:34px;
-  height:34px;
+  width:var(--p-hud-action, 34px);
+  height:var(--p-hud-action, 34px);
   border-width:2px;
 }
 html.tcg-portrait-play .pb-phase-actions .time-pie.phase-timer-pie > span{
-  font-size:13px;
+  font-size:calc(13px * var(--p-ui-scale, 1));
   letter-spacing:0;
 }
 html.tcg-portrait-play .pb-menu-wrap{
@@ -2246,15 +2271,15 @@ html.tcg-portrait-play .pb-menu-wrap{
   z-index:62;
 }
 html.tcg-portrait-play .pb-menu-btn{
-  width:34px;
-  height:34px;
-  min-width:34px;
+  width:var(--p-hud-action, 34px);
+  height:var(--p-hud-action, 34px);
+  min-width:var(--p-hud-action, 34px);
   padding:0;
   border-radius:10px;
   border:1px solid rgba(186,228,255,.35);
   background:rgba(8,14,28,.92);
   color:#fff;
-  font-size:18px;
+  font-size:calc(18px * var(--p-ui-scale, 1));
   line-height:1;
   display:inline-flex;
   align-items:center;

--- a/client/css/portrait.css
+++ b/client/css/portrait.css
@@ -2064,6 +2064,7 @@ html.tcg-portrait-play .pb-hud .stage-board-grid{
 }
 html.tcg-portrait-play .pb-hud .stage-board-side-lbl{ display:none; }
 html.tcg-portrait-play .pb-hud .stage-board-side{
+  display:flex;
   flex-direction:row;
   align-items:center;
   gap:4px;

--- a/client/css/portrait.css
+++ b/client/css/portrait.css
@@ -1227,7 +1227,10 @@ html.tcg-portrait-play{
   --opp-hand-card-h: calc(var(--p-card-h) * 0.92);
   --p-board-max-w: 100%;
   --p-field-min: 110px;
-  --p-hud-max: 26vh;
+  /* Fixed CSS-px HUD height so phones with full hearts match empty-board
+     phones — never let mid-bar grow toward a large vh fraction. */
+  --p-hud-h: 100px;
+  --p-hud-max: var(--p-hud-h);
 }
 
 /* Square foldables: reclaim vertical space so both fields stay playable. */
@@ -1237,7 +1240,8 @@ html.tcg-portrait-play.tcg-portrait-square{
   --p-hand-mine: calc(var(--p-card-h) * 0.50);
   --p-hand-opp: calc(var(--p-card-h) * 0.40);
   --p-field-min: 96px;
-  --p-hud-max: 18vh;
+  --p-hud-h: 96px;
+  --p-hud-max: var(--p-hud-h);
   --p-stage-outline-scale: 0.58;
   --p-live-outline-scale: 0.78;
 }
@@ -1250,7 +1254,8 @@ html.tcg-portrait-play.tcg-portrait-tablet{
   --p-hand-mine: calc(var(--p-card-h) * 0.54);
   --p-hand-opp: calc(var(--p-card-h) * 0.48);
   --p-field-min: 160px;
-  --p-hud-max: 22vh;
+  --p-hud-h: 108px;
+  --p-hud-max: var(--p-hud-h);
   --p-stage-outline-scale: 1;
   --p-live-outline-scale: 1;
 }
@@ -1329,11 +1334,14 @@ html.tcg-portrait-play .pb-opp-hand::-webkit-scrollbar{display:none}
 html.tcg-portrait-play .pb-opp-field{ grid-area: opp-field; min-height:0; overflow:visible; display:flex; z-index:4; }
 html.tcg-portrait-play .pb-hud{
   grid-area: hud;
-  flex:0 0 auto;
+  flex:0 0 var(--p-hud-h, var(--p-hud-max, 100px));
+  height: var(--p-hud-h, var(--p-hud-max, 100px));
+  min-height: var(--p-hud-h, var(--p-hud-max, 100px));
+  max-height: var(--p-hud-h, var(--p-hud-max, 100px));
   z-index:8;
-  max-height: var(--p-hud-max, 26vh);
   overflow-x:hidden;
-  overflow-y:auto;
+  overflow-y:hidden;
+  box-sizing:border-box;
 }
 /* Burger Log/Resign pop opens upward — lift the HUD so overflow does not clip it
    under the center info rectangle / adjacent playmat layers. */
@@ -1852,16 +1860,17 @@ html.tcg-portrait-play #screen-game .mslot .field-badge.field-hearts .stat-mod-b
 html.tcg-portrait-play .pb-hud{
   display:flex;
   flex-direction:column;
-  gap:3px;
+  justify-content:center;
+  gap:2px;
   position:relative;
-  /* Room for corner names: opp top-right, you bottom-left */
-  padding:18px 6px 18px;
+  /* Corner names are absolute — keep padding tight so HUD height stays fixed. */
+  padding:10px 6px 10px;
   margin:0;
   background: rgba(8, 14, 28, .94);
   border: 1px solid rgba(186,228,255,.22);
   border-radius: 12px;
   box-shadow: 0 4px 18px rgba(0,0,0,.35);
-  overflow:visible;
+  /* overflow-y stays hidden from the grid rule; menu-open lifts it. */
 }
 html.tcg-portrait-play .pb-wins-row{
   display:grid;
@@ -1870,6 +1879,9 @@ html.tcg-portrait-play .pb-wins-row{
   gap:4px;
   width:100%;
   min-width:0;
+  flex:0 0 auto;
+  min-height:22px;
+  max-height:24px;
 }
 html.tcg-portrait-play .pb-side{
   display:flex;
@@ -2036,26 +2048,49 @@ html.tcg-portrait-play .pb-hud .stage-board-panel{
   margin:0;
   background:transparent;
   border:none;
+  flex:0 0 auto;
+  min-height:0;
+  max-height:18px;
+  overflow:hidden;
 }
 html.tcg-portrait-play .pb-hud .stage-board-panel > h4{ display:none; }
 html.tcg-portrait-play .pb-hud .stage-board-grid{
   display:grid;
   grid-template-columns:1fr 1fr;
-  gap:6px;
+  gap:4px 6px;
+  align-items:center;
+  min-height:0;
+  height:18px;
 }
 html.tcg-portrait-play .pb-hud .stage-board-side-lbl{ display:none; }
+html.tcg-portrait-play .pb-hud .stage-board-side{
+  flex-direction:row;
+  align-items:center;
+  gap:4px;
+  min-width:0;
+  min-height:0;
+  max-height:18px;
+  overflow:hidden;
+}
 html.tcg-portrait-play .pb-hud .stage-board-side.mine{
-  align-items:flex-start;
+  align-items:center;
+  justify-content:flex-start;
 }
 html.tcg-portrait-play .pb-hud .stage-board-side.opp{
-  align-items:flex-end;
+  align-items:center;
+  justify-content:flex-end;
 }
 html.tcg-portrait-play .pb-hud .stage-board-hearts{
-  min-height:14px;
+  min-height:0;
+  max-height:18px;
   display:flex;
-  flex-wrap:wrap;
-  gap:2px 6px;
-  width:100%;
+  flex-wrap:nowrap;
+  align-items:center;
+  gap:2px 4px;
+  width:auto;
+  min-width:0;
+  flex:1 1 auto;
+  overflow:hidden;
 }
 html.tcg-portrait-play .pb-hud .stage-board-side.mine .stage-board-hearts,
 html.tcg-portrait-play .pb-hud .stage-board-side.mine .stage-board-yell{
@@ -2069,23 +2104,52 @@ html.tcg-portrait-play .pb-hud .stage-board-side.opp .stage-board-yell{
   text-align:right;
   flex-direction:row;
 }
+html.tcg-portrait-play .pb-hud .stage-board-hearts.empty{
+  font-size:10px!important;
+  line-height:1;
+  min-height:0;
+}
 html.tcg-portrait-play .pb-hud .stage-board-side.opp .stage-board-hearts.empty{
   text-align:right;
   justify-content:flex-end!important;
 }
+html.tcg-portrait-play .pb-hud .stage-board-hearts .heart-stat-row{
+  display:inline-flex;
+  align-items:center;
+  gap:2px;
+  font-size:10px!important;
+  font-weight:800;
+  line-height:1;
+  flex:0 0 auto;
+  white-space:nowrap;
+}
+html.tcg-portrait-play .pb-hud .stage-board-hearts .heart-stat-count,
+html.tcg-portrait-play .pb-hud .stage-board-hearts .stat-mod-bonus{
+  font-size:10px!important;
+  line-height:1!important;
+}
 html.tcg-portrait-play .pb-hud .stage-board-hearts img,
 html.tcg-portrait-play .pb-hud .stage-board-hearts .ticon,
 html.tcg-portrait-play .pb-hud .stage-board-hearts .hicon{
-  width:13px!important;
-  height:13px!important;
+  width:12px!important;
+  height:12px!important;
 }
 html.tcg-portrait-play .pb-hud .stage-board-yell{
   display:flex;
   align-items:center;
-  gap:4px;
+  gap:3px;
   font-size:10px;
+  line-height:1;
   opacity:.85;
-  width:100%;
+  width:auto;
+  flex:0 0 auto;
+  white-space:nowrap;
+  max-height:18px;
+  overflow:hidden;
+}
+html.tcg-portrait-play .pb-hud .stage-board-yell .bicon{
+  width:12px!important;
+  height:12px!important;
 }
 html.tcg-portrait-play .pb-hud .stage-board-active,
 html.tcg-portrait-play .pb-hud .stage-board-abilities{ display:none!important; }
@@ -2096,9 +2160,13 @@ html.tcg-portrait-play .pb-phase-row{
   align-items:center;
   justify-content:center;
   width:100%;
-  padding:2px 0 0;
+  padding:0;
   position:relative;
   z-index:12;
+  flex:0 0 34px;
+  min-height:34px;
+  height:34px;
+  max-height:34px;
 }
 html.tcg-portrait-play .pb-hud.pb-menu-open .pb-phase-row,
 html.tcg-portrait-play .pb-hud:has(.pb-menu-pop:not([hidden])) .pb-phase-row{
@@ -3352,7 +3420,10 @@ html.tcg-portrait-play.tcg-low-end .pb-deck-drawer{
 
 /* ── Square / tablet refinements ── */
 html.tcg-portrait-play.tcg-portrait-square .pb-hud{
-  max-height: var(--p-hud-max, 18vh);
+  flex-basis: var(--p-hud-h, var(--p-hud-max, 96px));
+  height: var(--p-hud-h, var(--p-hud-max, 96px));
+  min-height: var(--p-hud-h, var(--p-hud-max, 96px));
+  max-height: var(--p-hud-h, var(--p-hud-max, 96px));
 }
 html.tcg-portrait-play.tcg-portrait-square #screen-game .card-hover-panel,
 html.tcg-portrait-play.tcg-portrait-square #screen-game #card-hover-panel{

--- a/client/css/portrait.css
+++ b/client/css/portrait.css
@@ -1860,11 +1860,11 @@ html.tcg-portrait-play #screen-game .mslot .field-badge.field-hearts .stat-mod-b
 html.tcg-portrait-play .pb-hud{
   display:flex;
   flex-direction:column;
-  justify-content:center;
+  justify-content:flex-start;
   gap:2px;
   position:relative;
   /* Corner names are absolute — keep padding tight so HUD height stays fixed. */
-  padding:10px 6px 10px;
+  padding:10px 6px 8px;
   margin:0;
   background: rgba(8, 14, 28, .94);
   border: 1px solid rgba(186,228,255,.22);

--- a/client/css/portrait.css
+++ b/client/css/portrait.css
@@ -1222,6 +1222,8 @@ html.tcg-portrait-play{
      Keep scale modest so portrait members clear the hand-fan overhang. */
   --p-stage-outline-scale: 0.62;
   --p-live-outline-scale: 0.82;
+  /* Live storage row height cap (vw); shrunk on small phones with --p-ui-scale. */
+  --p-live-row: 16vw;
   /* Defeat landscape hand-strip vars that blow cards past the field */
   --hand-strip-h: var(--p-hand-mine);
   --my-hand-card-h: var(--p-card-h);
@@ -1239,11 +1241,16 @@ html.tcg-portrait-play{
   --p-hud-max: var(--p-hud-h);
 }
 
-/* Discrete compact rail for clearly-small phones (ui-scale < 0.95). */
+/* Discrete compact rail for clearly-small phones (ui-scale < 0.95).
+   Also shrink hand / stage / live so the whole board stays proportional. */
 html.tcg-portrait-play.tcg-portrait-phone-sm{
   --p-field-min: 96px;
-  --p-stage-outline-scale: 0.58;
-  --p-live-outline-scale: 0.76;
+  --p-card-w: calc((100vw / var(--p-hand-visible)) * 1.55 * var(--p-ui-scale, 1));
+  --p-hand-mine: calc(var(--p-card-h) * 0.54);
+  --p-hand-opp: calc(var(--p-card-h) * 0.46);
+  --p-stage-outline-scale: calc(0.62 * var(--p-ui-scale, 1));
+  --p-live-outline-scale: calc(0.78 * var(--p-ui-scale, 1));
+  --p-live-row: calc(14.5vw * var(--p-ui-scale, 1));
 }
 
 /* Square foldables: reclaim vertical space so both fields stay playable. */
@@ -1621,7 +1628,7 @@ html.tcg-portrait-play #screen-game .opp-mat .playmat-overlay{
   grid-template-columns: repeat(3, minmax(0, 1fr));
   /* Live row is sized to the live card so its slack cannot become a gap;
      all spare height collects in the stage row, on the hand side. */
-  grid-template-rows: minmax(0, 1fr) minmax(0, 16vw);
+  grid-template-rows: minmax(0, 1fr) minmax(0, var(--p-live-row, 16vw));
   grid-template-areas:
     "sr sc sl"
     "l2 l1 l0";
@@ -1630,7 +1637,7 @@ html.tcg-portrait-play #screen-game .opp-mat .playmat-overlay{
 }
 html.tcg-portrait-play #screen-game .my-mat .playmat-overlay{
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-template-rows: minmax(0, 16vw) minmax(0, 1fr);
+  grid-template-rows: minmax(0, var(--p-live-row, 16vw)) minmax(0, 1fr);
   grid-template-areas:
     "l0 l1 l2"
     "sl sc sr";

--- a/client/js/portrait-board.js
+++ b/client/js/portrait-board.js
@@ -363,6 +363,14 @@
     const rawW = global.visualViewport?.width || global.innerWidth || board.clientWidth || 360;
     // Tablets: keep a phone-like column so the mat does not stretch edge-to-edge.
     const layoutW = size === 'tablet' ? Math.min(rawW, 720) : rawW;
+    let uiScale = 1;
+    if (size === 'phone') {
+      const rawScale = root.dataset.tcgPortraitUiScale
+        || root.style.getPropertyValue('--p-ui-scale')
+        || global.getComputedStyle?.(root)?.getPropertyValue('--p-ui-scale');
+      const parsed = parseFloat(String(rawScale || '').trim());
+      if (Number.isFinite(parsed) && parsed > 0) uiScale = parsed;
+    }
     let cardMul = 1.55;
     let mineFrac = 0.52;
     let oppFrac = 0.50;
@@ -374,9 +382,14 @@
       cardMul = 1.42;
       mineFrac = 0.54;
       oppFrac = 0.48;
+    } else {
+      // Small phones: shrink hand with the same density factor as HUD chrome.
+      cardMul = 1.55 * uiScale;
+      mineFrac = 0.52 * (0.9 + 0.1 * uiScale);
+      oppFrac = 0.50 * (0.9 + 0.1 * uiScale);
     }
     const cardSlots = 5;
-    const cardW = Math.max(44, (layoutW / cardSlots) * cardMul);
+    const cardW = Math.max(40, (layoutW / cardSlots) * cardMul);
     const cardH = cardW * (88 / 63);
     root.style.setProperty('--p-card-w', cardW.toFixed(2) + 'px');
     root.style.setProperty('--p-card-h', cardH.toFixed(2) + 'px');

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ if (/[?&]debug(?:=|&|$)/.test(location.search)) {
 <link rel="stylesheet" href="client/css/sleeves.css?v=24">
 <link rel="stylesheet" href="client/css/playmats.css?v=6">
 <link rel="stylesheet" href="client/css/tournament.css?v=13">
-<link rel="stylesheet" href="client/css/portrait.css?v=92">
+<link rel="stylesheet" href="client/css/portrait.css?v=93">
 <link rel="stylesheet" href="client/css/social.css?v=26">
 
 </head>
@@ -18057,6 +18057,23 @@ function tcgPortraitSizeClass(w = window.innerWidth, h = window.innerHeight) {
   return 'phone';
 }
 
+/**
+ * Shrink portrait HUD chrome on smaller CSS viewports (e.g. 360×780 vs ~390×844).
+ * Cards already track width; this scales fixed-px mid-bar controls/fonts.
+ * Returns a unitless factor in [0.82, 1].
+ */
+function tcgPortraitUiScale(w = window.innerWidth, h = window.innerHeight, size = 'phone') {
+  if (size !== 'phone') return 1;
+  const shortSide = Math.min(w, h);
+  const longSide = Math.max(w, h);
+  let s = Math.min(shortSide / 390, longSide / 844);
+  // Common 360-css Android phones: pull density down further so mid-bar chrome
+  // does not dominate playmats the way a near-1.0 scale still does.
+  if (shortSide <= 360) s = Math.min(s, 0.88);
+  if (shortSide <= 340 || longSide <= 680) s = Math.min(s, 0.84);
+  return Math.round(Math.max(0.82, Math.min(1, s)) * 1000) / 1000;
+}
+
 function tcgApplyPortraitPlayState(w = window.innerWidth, h = window.innerHeight) {
   const root = document.documentElement;
   const resolved = tcgResolvePortraitPlayActive(w, h);
@@ -18066,10 +18083,19 @@ function tcgApplyPortraitPlayState(w = window.innerWidth, h = window.innerHeight
   root.dataset.tcgPortraitAuto = resolved.auto ? '1' : '0';
   document.body?.classList.toggle('tcg-portrait-play-body', !!resolved.active);
   const size = resolved.active ? tcgPortraitSizeClass(w, h) : '';
+  const uiScale = resolved.active ? tcgPortraitUiScale(w, h, size || 'phone') : 1;
   root.classList.toggle('tcg-portrait-phone', size === 'phone');
   root.classList.toggle('tcg-portrait-square', size === 'square');
   root.classList.toggle('tcg-portrait-tablet', size === 'tablet');
+  root.classList.toggle('tcg-portrait-phone-sm', !!(resolved.active && size === 'phone' && uiScale < 0.95));
   root.dataset.tcgPortraitSize = size || '';
+  root.dataset.tcgPortraitUiScale = resolved.active ? String(uiScale) : '';
+  if (resolved.active) {
+    root.style.setProperty('--p-ui-scale', String(uiScale));
+  } else {
+    root.style.removeProperty('--p-ui-scale');
+    delete root.dataset.tcgPortraitUiScale;
+  }
   if (resolved.active && !was) {
     try { if (typeof tcgPortraitMountBoard === 'function') tcgPortraitMountBoard(); } catch (_) { /* ignore */ }
   } else if (!resolved.active && was) {

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ if (/[?&]debug(?:=|&|$)/.test(location.search)) {
 <link rel="stylesheet" href="client/css/sleeves.css?v=24">
 <link rel="stylesheet" href="client/css/playmats.css?v=6">
 <link rel="stylesheet" href="client/css/tournament.css?v=13">
-<link rel="stylesheet" href="client/css/portrait.css?v=91">
+<link rel="stylesheet" href="client/css/portrait.css?v=92">
 <link rel="stylesheet" href="client/css/social.css?v=26">
 
 </head>

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ if (/[?&]debug(?:=|&|$)/.test(location.search)) {
 <link rel="stylesheet" href="client/css/sleeves.css?v=24">
 <link rel="stylesheet" href="client/css/playmats.css?v=6">
 <link rel="stylesheet" href="client/css/tournament.css?v=13">
-<link rel="stylesheet" href="client/css/portrait.css?v=93">
+<link rel="stylesheet" href="client/css/portrait.css?v=94">
 <link rel="stylesheet" href="client/css/social.css?v=26">
 
 </head>
@@ -33678,7 +33678,7 @@ function mkNoImg(card){
 <script src="client/js/cpu-ai.js?v=11"></script>
 <script src="client/js/portrait-bridge.js?v=26"></script>
 <script src="client/js/portrait-deck.js?v=5"></script>
-<script src="client/js/portrait-board.js?v=22"></script>
+<script src="client/js/portrait-board.js?v=23"></script>
 <script>void bootApp();</script>
 </body>
 </html>

--- a/scripts/test_portrait_responsive.mjs
+++ b/scripts/test_portrait_responsive.mjs
@@ -431,6 +431,35 @@ if (!portraitCss.includes('html.tcg-portrait-play .stamp-picker')
   ok('portrait stamp picker is a high-z bottom sheet');
 }
 
+/* Mid-bar: fixed CSS-px height so populated hearts cannot inflate playmat crush. */
+if (!/--p-hud-h:\s*100px/.test(portraitCss)
+    || /--p-hud-max:\s*26vh/.test(portraitCss)
+    || /--p-hud-max:\s*18vh/.test(portraitCss)
+    || /--p-hud-max:\s*22vh/.test(portraitCss)) {
+  fail('portrait HUD must use a fixed px --p-hud-h (not large vh maxes)');
+} else {
+  ok('portrait HUD uses fixed px --p-hud-h');
+}
+if (!/html\.tcg-portrait-play \.pb-hud\{[^}]*height:\s*var\(--p-hud-h/.test(portraitCss)
+    || !/html\.tcg-portrait-play \.pb-hud\{[^}]*overflow-y:hidden/.test(portraitCss)) {
+  fail('portrait .pb-hud must lock height and hide vertical overflow');
+} else {
+  ok('portrait .pb-hud locks height with overflow-y hidden');
+}
+if (!/html\.tcg-portrait-play \.pb-hud \.stage-board-hearts\{[^}]*flex-wrap:nowrap/.test(portraitCss)
+    || !/html\.tcg-portrait-play \.pb-hud \.stage-board-hearts \.heart-stat-row\{[^}]*font-size:10px!important/.test(portraitCss)
+    || !/html\.tcg-portrait-play \.pb-hud \.stage-board-side\{[^}]*flex-direction:row/.test(portraitCss)) {
+  fail('portrait HUD hearts must stay on one dense inline row');
+} else {
+  ok('portrait HUD hearts stay on one dense inline row');
+}
+if (!/html\.tcg-portrait-play \.pb-phase-row\{[^}]*min-height:34px/.test(portraitCss)
+    || !/html\.tcg-portrait-play \.pb-phase-row\{[^}]*height:34px/.test(portraitCss)) {
+  fail('portrait phase row must reserve a stable End-Main / timer height');
+} else {
+  ok('portrait phase row reserves stable action height');
+}
+
 if (process.exitCode) {
   console.error('\nPortrait responsive checks failed.');
   process.exit(process.exitCode);

--- a/scripts/test_portrait_responsive.mjs
+++ b/scripts/test_portrait_responsive.mjs
@@ -494,6 +494,20 @@ if (!indexSrc.includes('tcg-portrait-phone-sm')
 } else {
   ok('small-phone density class/scale wired');
 }
+if (!portraitCss.includes('--p-live-row')
+    || !/tcg-portrait-phone-sm\{[^}]*--p-live-outline-scale:\s*calc\(0\.78 \* var\(--p-ui-scale/.test(portraitCss)
+    || !/tcg-portrait-phone-sm\{[^}]*--p-stage-outline-scale:\s*calc\(0\.62 \* var\(--p-ui-scale/.test(portraitCss)
+    || !/tcg-portrait-phone-sm\{[^}]*--p-card-w:\s*calc\(\(100vw \/ var\(--p-hand-visible\)\) \* 1\.55 \* var\(--p-ui-scale/.test(portraitCss)) {
+  fail('phone-sm must scale hand + stage/live slots with --p-ui-scale');
+} else {
+  ok('phone-sm scales hand + stage/live slots');
+}
+if (!boardJs.includes('1.55 * uiScale')
+    || !boardJs.includes('tcgPortraitUiScale') && !boardJs.includes('dataset.tcgPortraitUiScale')) {
+  fail('portrait-board syncHandVars must apply uiScale to hand cardMul');
+} else {
+  ok('portrait-board applies uiScale to hand cardMul');
+}
 
 if (process.exitCode) {
   console.error('\nPortrait responsive checks failed.');

--- a/scripts/test_portrait_responsive.mjs
+++ b/scripts/test_portrait_responsive.mjs
@@ -25,6 +25,7 @@ const bridgeJs = fs.readFileSync(path.join(root, 'client', 'js', 'portrait-bridg
 for (const needle of [
   'tcgResolvePortraitPlayActive',
   'tcgPortraitSizeClass',
+  'tcgPortraitUiScale',
   'tcgApplyPortraitPlayState',
   'tcgPortraitTouchPrimary',
   'tcgPortraitUnmountBoard',
@@ -432,13 +433,13 @@ if (!portraitCss.includes('html.tcg-portrait-play .stamp-picker')
 }
 
 /* Mid-bar: fixed CSS-px height so populated hearts cannot inflate playmat crush. */
-if (!/--p-hud-h:\s*100px/.test(portraitCss)
+if (!/--p-hud-h:\s*calc\(100px \* var\(--p-ui-scale/.test(portraitCss)
     || /--p-hud-max:\s*26vh/.test(portraitCss)
     || /--p-hud-max:\s*18vh/.test(portraitCss)
     || /--p-hud-max:\s*22vh/.test(portraitCss)) {
-  fail('portrait HUD must use a fixed px --p-hud-h (not large vh maxes)');
+  fail('portrait HUD must use a scaled px --p-hud-h (not large vh maxes)');
 } else {
-  ok('portrait HUD uses fixed px --p-hud-h');
+  ok('portrait HUD uses scaled px --p-hud-h');
 }
 if (!/html\.tcg-portrait-play \.pb-hud\{[^}]*height:\s*var\(--p-hud-h/.test(portraitCss)
     || !/html\.tcg-portrait-play \.pb-hud\{[^}]*overflow-y:hidden/.test(portraitCss)) {
@@ -447,17 +448,51 @@ if (!/html\.tcg-portrait-play \.pb-hud\{[^}]*height:\s*var\(--p-hud-h/.test(port
   ok('portrait .pb-hud locks height with overflow-y hidden');
 }
 if (!/html\.tcg-portrait-play \.pb-hud \.stage-board-hearts\{[^}]*flex-wrap:nowrap/.test(portraitCss)
-    || !/html\.tcg-portrait-play \.pb-hud \.stage-board-hearts \.heart-stat-row\{[^}]*font-size:10px!important/.test(portraitCss)
+    || !/html\.tcg-portrait-play \.pb-hud \.stage-board-hearts \.heart-stat-row\{[^}]*font-size:calc\(10px \* var\(--p-ui-scale/.test(portraitCss)
     || !/html\.tcg-portrait-play \.pb-hud \.stage-board-side\{[^}]*flex-direction:row/.test(portraitCss)) {
   fail('portrait HUD hearts must stay on one dense inline row');
 } else {
   ok('portrait HUD hearts stay on one dense inline row');
 }
-if (!/html\.tcg-portrait-play \.pb-phase-row\{[^}]*min-height:34px/.test(portraitCss)
-    || !/html\.tcg-portrait-play \.pb-phase-row\{[^}]*height:34px/.test(portraitCss)) {
+if (!/html\.tcg-portrait-play \.pb-phase-row\{[^}]*min-height:var\(--p-hud-action/.test(portraitCss)
+    || !/html\.tcg-portrait-play \.pb-phase-row\{[^}]*height:var\(--p-hud-action/.test(portraitCss)) {
   fail('portrait phase row must reserve a stable End-Main / timer height');
 } else {
   ok('portrait phase row reserves stable action height');
+}
+
+/** Mirror of tcgPortraitUiScale for small-phone density. */
+function uiScale(w, h, size = 'phone') {
+  if (size !== 'phone') return 1;
+  const shortSide = Math.min(w, h);
+  const longSide = Math.max(w, h);
+  let s = Math.min(shortSide / 390, longSide / 844);
+  if (shortSide <= 360) s = Math.min(s, 0.88);
+  if (shortSide <= 340 || longSide <= 680) s = Math.min(s, 0.84);
+  return Math.round(Math.max(0.82, Math.min(1, s)) * 1000) / 1000;
+}
+const scaleFixtures = [
+  { w: 390, h: 844, expect: 1, sm: false, label: 'reference phone' },
+  { w: 360, h: 780, expect: 0.88, sm: true, label: 'small Android 360' },
+  { w: 360, h: 640, expect: 0.82, sm: true, label: 'short 360×640 floors at 0.82' },
+  { w: 320, h: 568, expect: 0.82, sm: true, label: 'very small phone floors at 0.82' },
+  { w: 412, h: 915, expect: 1, sm: false, label: 'large Android phone' },
+  { w: 768, h: 1024, size: 'tablet', expect: 1, sm: false, label: 'tablet ignores phone scale' },
+];
+for (const f of scaleFixtures) {
+  const got = uiScale(f.w, f.h, f.size || 'phone');
+  if (got !== f.expect) fail(`uiScale ${f.label}: expected ${f.expect}, got ${got}`);
+  else ok(`uiScale ${f.label} → ${got}`);
+  const sm = (f.size || 'phone') === 'phone' && got < 0.95;
+  if (sm !== f.sm) fail(`phone-sm ${f.label}: expected ${f.sm}, got ${sm}`);
+  else ok(`phone-sm ${f.label} → ${sm}`);
+}
+if (!indexSrc.includes('tcg-portrait-phone-sm')
+    || !portraitCss.includes('tcg-portrait-phone-sm')
+    || !indexSrc.includes('--p-ui-scale')) {
+  fail('small-phone density class/scale must be wired in index + portrait.css');
+} else {
+  ok('small-phone density class/scale wired');
 }
 
 if (process.exitCode) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
On smaller phones the portrait middle HUD grew too tall, and hand cards plus stage/live storage slots also looked oversized relative to the playmats.

## Fix
- Lock mid-bar to a fixed CSS-px height (no large vh growth); dense hearts/yell on one row
- Add `--p-ui-scale` (`tcgPortraitUiScale`): ~390×844 stays at **1**; common **360-css** phones ~**0.88** (floor **0.82**)
- Scale mid-bar chrome with `--p-ui-scale`
- Also scale **hand** (`cardMul`), **stage/live outlines**, and **live-row height** on `tcg-portrait-phone-sm` so the whole board stays proportional

## Verification
- `scripts/test_portrait_responsive.mjs` mid-bar + uiScale + phone-sm hand/slot contracts (pass; unrelated pre-existing hand-fan assertion still fails on baseline)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

