### PR TITLE
Long-press stage/live cards to open card info on mobile

### DIFF
--- a/client/js/board-render.js
+++ b/client/js/board-render.js
@@ -1257,7 +1257,7 @@ function renderStageSlots(prefix, stage, isMe, s, myId) {
             requestAnimationFrame(() => scheduleStageFlipReveal(d, flipKey, flipKeys));
           });
         });
-        d.onclick = G.isSpectator ? null : () => showCard(mbr, null, s, myId);
+        d.onclick = G.isSpectator ? null : boardCardShowClickHandler(mbr, s, myId);
       } else if(mbr.image || mbr.card_no){
         const img = document.createElement('img');
         img.alt = mbr.name_en||mbr.name;
@@ -1267,12 +1267,12 @@ function renderStageSlots(prefix, stage, isMe, s, myId) {
           d.appendChild(mkNoImg(mbr));
         } else d.appendChild(img);
         d.classList.add('occupied');
-        d.onclick = G.isSpectator ? null : () => showCard(mbr, null, s, myId);
+        d.onclick = G.isSpectator ? null : boardCardShowClickHandler(mbr, s, myId);
         applyCardFoilFx(d, mbr);
       } else {
         d.appendChild(mkNoImg(mbr));
         d.classList.add('occupied');
-        d.onclick = G.isSpectator ? null : () => showCard(mbr, null, s, myId);
+        d.onclick = G.isSpectator ? null : boardCardShowClickHandler(mbr, s, myId);
         applyCardFoilFx(d, mbr);
       }
       const printedHearts = (typeof memberPrintedHeartGroups === 'function')
@@ -1291,6 +1291,9 @@ function renderStageSlots(prefix, stage, isMe, s, myId) {
       appendMemberStackedEnergyBadge(d, mbr, s?.players?.[ownerPid]);
       appendMemberStackedMembersBadge(d, mbr);
       if (isMe) bindMyStageCardInspect(d, mbr, s, myId);
+      if (!G.isSpectator && typeof bindBoardCardLongPressInspect === 'function') {
+        bindBoardCardLongPressInspect(d, mbr, s, myId);
+      }
     }
     outer.appendChild(d);
     if (mbr) {
@@ -2230,8 +2233,13 @@ function renderSuccessLives(id, succs) {
     appendCardFace(d, sc, { sideways: liveStorageUseArtSpin(sc) });
     wrap.appendChild(d);
     wrap.title = sc.name_en || sc.name || 'Live Success';
-    wrap.onclick = () => showCard(sc, null, G.gameState, G.playerId);
+    wrap.onclick = typeof boardCardShowClickHandler === 'function'
+      ? boardCardShowClickHandler(sc, G.gameState, G.playerId)
+      : () => showCard(sc, null, G.gameState, G.playerId);
     bindSuccessLiveHover(wrap, sc, G.gameState, G.playerId);
+    if (typeof bindBoardCardLongPressInspect === 'function') {
+      bindBoardCardLongPressInspect(wrap, sc, G.gameState, G.playerId);
+    }
     stack.appendChild(wrap);
   });
   e.appendChild(stack);
@@ -2389,13 +2397,24 @@ function renderLiveSlots(prefix, zone, isMe, pid){
       d.appendChild(buildLiveStorageFlipInner(card));
       layoutLiveSlots(prefix);
       ensureLiveStorageFlipScheduled(d, card, flipKey, flipKeys, i * LIVE_STORAGE_FLIP_STAGGER_MS, prefix);
-      d.onclick = G.isSpectator ? null : () => showCard(card, null, G.gameState, isMe ? G.playerId : pid);
+      d.onclick = G.isSpectator ? null : (
+        typeof boardCardShowClickHandler === 'function'
+          ? boardCardShowClickHandler(card, G.gameState, isMe ? G.playerId : pid)
+          : () => showCard(card, null, G.gameState, isMe ? G.playerId : pid)
+      );
     } else {
       appendLiveStorageFace(d, card);
-      d.onclick = G.isSpectator ? null : () => showCard(card, null, G.gameState, isMe ? G.playerId : pid);
+      d.onclick = G.isSpectator ? null : (
+        typeof boardCardShowClickHandler === 'function'
+          ? boardCardShowClickHandler(card, G.gameState, isMe ? G.playerId : pid)
+          : () => showCard(card, null, G.gameState, isMe ? G.playerId : pid)
+      );
     }
     d.classList.toggle('card-arriving', !!(G._animHideIids?.has(card.instance_id)));
     if(showFace) applyCardFoilFx(d, card);
+    if (showFace && !G.isSpectator && typeof bindBoardCardLongPressInspect === 'function') {
+      bindBoardCardLongPressInspect(d, card, G.gameState, isMe ? G.playerId : pid);
+    }
     outer.appendChild(d);
     if(showFace && card.score != null && ((!hiddenSpectate && isMe) || card.revealed)){
       const extraBonus = stagePreview && i === lastScoredLiveSlot ? stageBonus : 0;

--- a/index.html
+++ b/index.html
@@ -27302,6 +27302,77 @@ function bindMyStageCardInspect(mslot, card, s, myId) {
   });
 }
 
+/**
+ * Stage / live-storage (and similar board faces): tap already opens card info;
+ * also open on long-press like hand cards (mobile currently did nothing on hold).
+ */
+function boardCardShowClickHandler(card, s, viewPid) {
+  return () => {
+    if (Date.now() < (G._boardCardLongPressSuppressClickUntil || 0)) return;
+    if (G.isSpectator) return;
+    showCard(card, card?.instance_id || null, s || G.gameState, viewPid || G.playerId);
+  };
+}
+
+function bindBoardCardLongPressInspect(node, card, s, viewPid) {
+  if (!node || !card || G.isSpectator || G.isTutorial) return;
+  if (node.classList?.contains('live-storage-facedown')) return;
+  if (card.revealed === false || card.card_no === '?') return;
+  if (node._boardLongPressBound) return;
+  node._boardLongPressBound = true;
+  node.addEventListener('pointerdown', e => {
+    if (e.button !== 0) return;
+    if (G.animating || G.drag) return;
+    const ptr = {
+      sx: e.clientX,
+      sy: e.clientY,
+      moved: false,
+      longFired: false,
+      pointerId: e.pointerId,
+      timer: null,
+    };
+    ptr.timer = setTimeout(() => {
+      if (ptr.moved || G.drag) return;
+      ptr.longFired = true;
+      G._boardCardLongPressSuppressClickUntil = Date.now() + 500;
+      try {
+        if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(12);
+      } catch (_) { /* ignore */ }
+      const state = (typeof liveGameState === 'function' ? liveGameState(s) : null) || s || G.gameState;
+      showCard(card, card.instance_id || null, state, viewPid || G.playerId);
+    }, typeof LONG_PRESS_MS === 'number' ? LONG_PRESS_MS : 420);
+    const moveThresh = typeof DRAG_THRESHOLD === 'number' ? DRAG_THRESHOLD : 10;
+    const onMove = ev => {
+      if (ev.pointerId !== ptr.pointerId) return;
+      if (Math.hypot(ev.clientX - ptr.sx, ev.clientY - ptr.sy) > moveThresh) {
+        ptr.moved = true;
+        if (ptr.timer) {
+          clearTimeout(ptr.timer);
+          ptr.timer = null;
+        }
+      }
+    };
+    const onUp = ev => {
+      if (ev.pointerId !== ptr.pointerId) return;
+      if (ptr.timer) clearTimeout(ptr.timer);
+      document.removeEventListener('pointermove', onMove, true);
+      document.removeEventListener('pointerup', onUp, true);
+      document.removeEventListener('pointercancel', onUp, true);
+    };
+    document.addEventListener('pointermove', onMove, true);
+    document.addEventListener('pointerup', onUp, true);
+    document.addEventListener('pointercancel', onUp, true);
+  });
+  node.addEventListener('contextmenu', e => {
+    // Avoid the native callout competing with long-press inspect on mobile.
+    if (typeof tcgPortraitPlayActive === 'function' && tcgPortraitPlayActive()) {
+      e.preventDefault();
+    } else if (typeof tcgMobileViewportActive === 'function' && tcgMobileViewportActive()) {
+      e.preventDefault();
+    }
+  });
+}
+
 function bindHandCardEvents(d, card, s, myId) {
   if (G.isSpectator) return;
   // Slideshow tutorial never plays from hand. Live tutorial always binds once —
@@ -33643,7 +33714,7 @@ function mkNoImg(card){
 </script>
 <script src="client/js/live-round-director.js?v=3"></script>
 <script src="client/js/spectacle.js?v=108"></script>
-<script src="client/js/board-render.js?v=43"></script>
+<script src="client/js/board-render.js?v=44"></script>
 <script src="client/js/components/board-zones.js?v=1"></script>
 <script src="client/js/cpu-meta-weights.js?v=6"></script>
 <script src="client/js/cpu-eval.js?v=6"></script>

--- a/scripts/test_board_longpress_inspect.mjs
+++ b/scripts/test_board_longpress_inspect.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Stage / live long-press inspect contracts (source-level).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+let failed = 0;
+function fail(msg) { console.error(`FAIL: ${msg}`); failed = 1; }
+function ok(msg) { console.log(`OK: ${msg}`); }
+
+const indexSrc = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const boardSrc = fs.readFileSync(path.join(root, 'client', 'js', 'board-render.js'), 'utf8');
+
+if (!indexSrc.includes('function bindBoardCardLongPressInspect')
+    || !indexSrc.includes('function boardCardShowClickHandler')
+    || !indexSrc.includes('_boardCardLongPressSuppressClickUntil')) {
+  fail('index.html must define board long-press inspect helpers');
+} else {
+  ok('index.html defines board long-press inspect helpers');
+}
+
+const calls = (boardSrc.match(/bindBoardCardLongPressInspect\(/g) || []).length;
+if (calls < 3) {
+  fail(`board-render must bind long-press on stage/live/success (got ${calls})`);
+} else {
+  ok(`board-render binds long-press (${calls} call sites)`);
+}
+
+if (!(boardSrc.match(/boardCardShowClickHandler\(/g) || []).length) {
+  fail('board-render must use boardCardShowClickHandler to suppress click-after-hold');
+} else {
+  ok('board-render uses click suppress helper');
+}
+
+if (!/live-storage-facedown/.test(indexSrc)
+    || !/card\.revealed === false/.test(indexSrc)) {
+  fail('long-press must skip face-down / unrevealed cards');
+} else {
+  ok('long-press skips face-down / unrevealed cards');
+}
+
+if (failed) {
+  console.error('\nBoard long-press inspect checks failed.');
+  process.exit(1);
+}
+console.log('\nBoard long-press inspect checks passed.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
On mobile, tapping a stage or live-storage card opens card info, but long-pressing those cards did nothing. Hand cards already open info on long-press.

## Fix
- Add `bindBoardCardLongPressInspect` + `boardCardShowClickHandler` (suppresses the synthetic click after a hold)
- Wire long-press on stage members, face-up live storage, and success-live chips
- Skip face-down / unrevealed cards
- Prevent mobile context-menu callout from fighting the hold gesture

## Test
- `node scripts/test_board_longpress_inspect.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

