### PR TITLE
Fix ?debug mid-match reload auto-resigning

### DIFF
--- a/client/js/resign-escape.js
+++ b/client/js/resign-escape.js
@@ -1,0 +1,82 @@
+/**
+ * Softlock resign-escape URL rules (browser + Node).
+ * Only an enabled ?resign on THIS load may concede. Stale sessionStorage
+ * from an interrupted escape must not fire on later reloads (e.g. ?debug).
+ */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  if (root) root.LLTCG_RESIGN_ESCAPE = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  const STORAGE_KEY = 'tcg_resign_escape';
+
+  function resignParamEnabled(raw) {
+    const v = String(raw ?? '').trim().toLowerCase();
+    return v === '' || !['0', 'false', 'no', 'off'].includes(v);
+  }
+
+  /**
+   * @param {string} search location.search (with or without leading ?)
+   * @returns {{
+   *   escape: boolean,
+   *   clearStale: boolean,
+   *   setStale: boolean,
+   *   stripResign: boolean,
+   *   remainingSearch: string,
+   * }}
+   */
+  function planResignEscapeFromSearch(search) {
+    const rawSearch = String(search || '');
+    const q = rawSearch.startsWith('?') ? rawSearch.slice(1) : rawSearch;
+    const params = new URLSearchParams(q);
+    if (!params.has('resign')) {
+      // Drop leftover softlock flag so mid-match ?debug (or any non-resign reload)
+      // reconnects instead of auto-resigning.
+      return {
+        escape: false,
+        clearStale: true,
+        setStale: false,
+        stripResign: false,
+        remainingSearch: rawSearch.startsWith('?') || rawSearch === '' ? rawSearch : `?${rawSearch}`,
+      };
+    }
+    const enabled = resignParamEnabled(params.get('resign'));
+    params.delete('resign');
+    const qs = params.toString();
+    const remainingSearch = qs ? `?${qs}` : '';
+    if (!enabled) {
+      return {
+        escape: false,
+        clearStale: true,
+        setStale: false,
+        stripResign: true,
+        remainingSearch,
+      };
+    }
+    return {
+      escape: true,
+      clearStale: false,
+      setStale: true,
+      stripResign: true,
+      remainingSearch,
+    };
+  }
+
+  /** True when URL enables verbose debug tooling (?debug / ?debug=all / …). */
+  function hasDebugQuery(search) {
+    const rawSearch = String(search || '');
+    const q = rawSearch.startsWith('?') ? rawSearch.slice(1) : rawSearch;
+    return new URLSearchParams(q).has('debug');
+  }
+
+  return {
+    STORAGE_KEY,
+    resignParamEnabled,
+    planResignEscapeFromSearch,
+    hasDebugQuery,
+  };
+});

--- a/index.html
+++ b/index.html
@@ -2880,6 +2880,7 @@ if (/[?&]debug(?:=|&|$)/.test(location.search)) {
 <script src="client/js/login-bonus.js?v=3"></script>
 <script src="client/js/discord-presence.js?v=12"></script>
 <script src="client/js/presentation-guards.js?v=7"></script>
+<script src="client/js/resign-escape.js?v=1"></script>
 <script src="client/js/game-sync.js?v=60"></script>
 <script src="client/js/state-apply.js?v=70"></script>
 <script src="client/js/stamps.js?v=21"></script>
@@ -5008,22 +5009,47 @@ function playPackOpenAnimation(cards, packImage, packStyle, faceSrcByIndex = nul
   })));
 }
 
-const RESIGN_ESCAPE_KEY = 'tcg_resign_escape';
+const RESIGN_ESCAPE_KEY = (typeof LLTCG_RESIGN_ESCAPE !== 'undefined' && LLTCG_RESIGN_ESCAPE.STORAGE_KEY)
+  ? LLTCG_RESIGN_ESCAPE.STORAGE_KEY
+  : 'tcg_resign_escape';
 
-/** Softlock escape: ?resign (or ?resign=1) forces leave/resign then returns to the menu. */
+/**
+ * Softlock escape: ?resign (or ?resign=1) forces leave/resign then returns to the menu.
+ * Mid-match ?debug (or any reload without ?resign) must NEVER auto-resign — clear any
+ * stale sessionStorage left from an interrupted prior escape.
+ */
 function captureResignEscapeFromUrl() {
   try {
-    const params = new URLSearchParams(location.search);
-    if (!params.has('resign')) return false;
-    // Accept bare ?resign, ?resign=1, ?resign=true (anything except explicit 0/false/no).
-    const raw = String(params.get('resign') ?? '').trim().toLowerCase();
-    const enabled = raw === '' || !['0', 'false', 'no', 'off'].includes(raw);
-    params.delete('resign');
-    const qs = params.toString();
-    history.replaceState({}, document.title, location.pathname + (qs ? '?' + qs : '') + location.hash);
-    if (!enabled) return false;
-    try { sessionStorage.setItem(RESIGN_ESCAPE_KEY, '1'); } catch (e) { /* ignore */ }
-    return true;
+    const plan = (typeof LLTCG_RESIGN_ESCAPE !== 'undefined' && LLTCG_RESIGN_ESCAPE.planResignEscapeFromSearch)
+      ? LLTCG_RESIGN_ESCAPE.planResignEscapeFromSearch(location.search)
+      : null;
+    if (!plan) {
+      // Fallback if script failed to load: never resign without an explicit ?resign.
+      const params = new URLSearchParams(location.search);
+      if (!params.has('resign')) {
+        clearResignEscape();
+        return false;
+      }
+      const raw = String(params.get('resign') ?? '').trim().toLowerCase();
+      const enabled = raw === '' || !['0', 'false', 'no', 'off'].includes(raw);
+      params.delete('resign');
+      const qs = params.toString();
+      history.replaceState({}, document.title, location.pathname + (qs ? '?' + qs : '') + location.hash);
+      if (!enabled) {
+        clearResignEscape();
+        return false;
+      }
+      try { sessionStorage.setItem(RESIGN_ESCAPE_KEY, '1'); } catch (e) { /* ignore */ }
+      return true;
+    }
+    if (plan.stripResign) {
+      history.replaceState({}, document.title, location.pathname + plan.remainingSearch + location.hash);
+    }
+    if (plan.clearStale) clearResignEscape();
+    if (plan.setStale) {
+      try { sessionStorage.setItem(RESIGN_ESCAPE_KEY, '1'); } catch (e) { /* ignore */ }
+    }
+    return !!plan.escape;
   } catch (e) {
     return false;
   }
@@ -6085,7 +6111,9 @@ async function resumeActiveGameIfAny() {
 
 async function initAccountFlow() {
   captureLovecaChallengeFromUrl();
-  const resignEscape = captureResignEscapeFromUrl() || peekResignEscape();
+  // Only a fresh ?resign on this load may escape. Do not OR peekResignEscape() —
+  // capture already clears stale flags when resign is absent (so ?debug reconnects).
+  const resignEscape = captureResignEscapeFromUrl();
   if (resignEscape) {
     // Do not reconnect into the stuck room — escape runs before resume queue.
     cancelReconnectQueue();

--- a/scripts/test_resign_escape.mjs
+++ b/scripts/test_resign_escape.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * ?resign softlock escape must not fire on mid-match ?debug reloads.
+ * node scripts/test_resign_escape.mjs
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const api = require(path.join(root, 'client/js/resign-escape.js'));
+const indexSrc = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+
+let failed = 0;
+function check(name, cond) {
+  if (cond) console.log(`OK: ${name}`);
+  else {
+    console.error(`FAIL: ${name}`);
+    failed += 1;
+  }
+}
+
+const plan = api.planResignEscapeFromSearch;
+
+check('bare ?debug does not escape', plan('?debug').escape === false);
+check('bare ?debug clears stale flag', plan('?debug').clearStale === true);
+check('?debug=all does not escape', plan('?debug=all').escape === false);
+check('?debug=poll,live does not escape', plan('?debug=poll,live').escape === false);
+check('empty search clears stale', plan('').clearStale === true && plan('').escape === false);
+
+check('bare ?resign escapes', plan('?resign').escape === true);
+check('?resign=1 escapes', plan('?resign=1').escape === true);
+check('?resign=true escapes', plan('?resign=true').escape === true);
+check('?resign=0 does not escape', plan('?resign=0').escape === false);
+check('?resign=false clears stale', plan('?resign=false').clearStale === true);
+
+const both = plan('?debug&resign');
+check('?debug&resign still escapes (explicit softlock)', both.escape === true);
+check('?debug&resign strips resign, keeps debug', both.remainingSearch === '?debug' || both.remainingSearch === '?debug=');
+
+const debugFirst = plan('?resign=1&debug=all');
+check('?resign=1&debug=all escapes', debugFirst.escape === true);
+check('strips resign only', debugFirst.remainingSearch === '?debug=all');
+
+check('hasDebugQuery recognizes ?debug', api.hasDebugQuery('?debug') === true);
+check('hasDebugQuery ignores bare resign', api.hasDebugQuery('?resign') === false);
+
+check('index loads resign-escape.js', /client\/js\/resign-escape\.js/.test(indexSrc));
+check('index uses planResignEscapeFromSearch', /planResignEscapeFromSearch/.test(indexSrc));
+check(
+  'index does not peek stale flag without capture',
+  /captureResignEscapeFromUrl\(\)\s*;/.test(indexSrc)
+    || !/captureResignEscapeFromUrl\(\)\s*\|\|\s*peekResignEscape\(\)/.test(indexSrc),
+);
+
+if (failed) {
+  console.error(`\n${failed} check(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll resign-escape checks passed.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Adding `?debug` and reloading mid-match could sometimes auto-resign. Softlock escape (`?resign`) stored `tcg_resign_escape` in `sessionStorage`; a later reload that only had `?debug` could still consume that stale flag and force-resign.

## Fix
- Extract URL rules to `client/js/resign-escape.js`
- Clear the stale escape flag whenever this load’s URL has **no** enabled `?resign`
- Boot only runs softlock escape from a fresh `captureResignEscapeFromUrl()` (not a leftover peek)
- Explicit `?debug&resign` still escapes (intentional softlock)

## Test
`node scripts/test_resign_escape.mjs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

