### PR TITLE
Gate Live Start to players performing Live cards

### DIFF
--- a/api.php
+++ b/api.php
@@ -2393,6 +2393,29 @@ function playerAttemptingLivePerformance(array $state, string $pid): bool {
     return false;
 }
 
+/**
+ * Whether Stage/Live [Live Start] skills may resolve for this seat.
+ * Member-bluff-only storage must not fire Live Start. Empty storage is allowed
+ * so isolated skill unit tests can call resolveLiveStartAbilities without a full
+ * Performance setup (real empty seats are already excluded from live_attempt).
+ */
+function playerShouldResolveLiveStart(array $state, string $pid): bool {
+    if (!empty($state['live_modifiers'][$pid]['cannot_live'])) {
+        return false;
+    }
+    $anyStorage = false;
+    foreach ($state['players'][$pid]['live_zone'] ?? [] as $c) {
+        if (!$c) {
+            continue;
+        }
+        $anyStorage = true;
+        if (isLiveTypeCard($c)) {
+            return true;
+        }
+    }
+    return !$anyStorage;
+}
+
 /** Instance ids of Live cards in storage — frozen for spectacle / Live Judge rows. */
 function snapshotLiveShowPlayedLives(array $state): array {
     $out = ['p1' => [], 'p2' => []];

--- a/src/Game/LiveStartEffects.php
+++ b/src/Game/LiveStartEffects.php
@@ -161,6 +161,12 @@ function resolveLiveStartAbilities(array $state, string $pid): array {
     if (!in_array($pid, $attempting, true)) {
         return $state;
     }
+    // Official Live Start is for performers attempting a Live — Member-bluff-only
+    // storage must not fire Stage [Live Start] (e.g. Kaho blade draw/discard).
+    if (function_exists('playerShouldResolveLiveStart')
+        && !playerShouldResolveLiveStart($state, $pid)) {
+        return $state;
+    }
     // Entry auras must run once per player per Live Start phase (resume re-enters this fn).
     $entryFlags = $state['live_start_entry_applied'] ?? [];
     if (empty($entryFlags[$pid])) {
@@ -392,6 +398,10 @@ function collectOptionalLiveStartAbilities(array $state): array {
     foreach (['p1', 'p2'] as $pid) {
         if (!in_array($pid, $attempting, true)) continue;
         if ($scopePid !== null && $pid !== $scopePid) continue;
+        if (function_exists('playerShouldResolveLiveStart')
+            && !playerShouldResolveLiveStart($state, $pid)) {
+            continue;
+        }
         foreach (liveStartSourcesLeftToRight($state, $pid) as $card) {
             if (isMemberCard($card) && memberLiveStartAbilitiesNegated($card)) {
                 continue;
@@ -763,6 +773,11 @@ function beginLiveStartForPerformer(array $state, string $pid): array {
     $state['phase'] = 'live_start_effects';
     // Keep optional/mandatory resolved markers so already-answered skills do not replay.
     unset($state['live_start_optional_queue']);
+    // Member-bluff-only seats still yell/skip — but do not open Live Start skills.
+    if (function_exists('playerAttemptingLivePerformance')
+        && !playerAttemptingLivePerformance($state, $pid)) {
+        return finishLiveStartEffects($state);
+    }
     if (performanceRoundHasLiveCards($state)) {
         $state = addLog($state, '=== Live Start Effects (' .
             ($state['players'][$pid]['name'] ?? $pid) . ') ===');

--- a/tests/Engine/LiveStartRequiresLiveCardsTest.php
+++ b/tests/Engine/LiveStartRequiresLiveCardsTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLTCG\Tests\Engine;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Live Start must not fire for a player who only set Member bluffs
+ * (no Live cards in storage) while the opponent is performing.
+ */
+final class LiveStartRequiresLiveCardsTest extends TestCase
+{
+    private function cardByNo(string $cardNo, string $instanceId): array
+    {
+        $data = json_decode((string) file_get_contents((string) constant('CARDS_FILE')), true);
+        $this->assertIsArray($data);
+        foreach ($data['cards'] ?? [] as $card) {
+            if (($card['card_no'] ?? '') === $cardNo) {
+                $card['instance_id'] = $instanceId;
+                $card['active'] = true;
+                return $card;
+            }
+        }
+        $this->fail('Missing test card ' . $cardNo);
+    }
+
+    private function bluffMember(string $id): array
+    {
+        return [
+            'instance_id' => $id,
+            'card_type' => 'メンバー',
+            'card_type_en' => 'Member',
+            'group' => 'Hasunosora',
+            'name_en' => 'Bluff',
+            'cost' => 2,
+            'blade' => 1,
+            'hearts' => [['color' => 'pink', 'count' => 1]],
+            'active' => true,
+        ];
+    }
+
+    private function plainLive(string $id): array
+    {
+        return [
+            'instance_id' => $id,
+            'card_type' => 'ライブ',
+            'card_type_en' => 'Live',
+            'group' => "μ's",
+            'name_en' => 'Dummy Live',
+            'score' => 1,
+            'required_hearts' => [['color' => 'any', 'count' => 1]],
+            'abilities' => [],
+        ];
+    }
+
+    /** Kaho with enough stacked Blade for her Live Start draw/discard. */
+    private function kahoWithBlades(): array
+    {
+        $kaho = $this->cardByNo('PL!HS-pb1-009-R', 'kaho');
+        // Bypass Always math — force ≥8 Blades for the Live Start gate check.
+        $kaho['printed_blade_override'] = 8;
+        $kaho['live_blade_bonus'] = 0;
+        return $kaho;
+    }
+
+    private function baseState(array $p1Live, array $p2Live, array $p2Center): array
+    {
+        $deck = [];
+        for ($i = 1; $i <= 12; $i++) {
+            $deck[] = [
+                'instance_id' => 'deck' . $i,
+                'card_type' => 'メンバー',
+                'card_type_en' => 'Member',
+                'group' => 'Hasunosora',
+                'name_en' => 'Deck' . $i,
+                'blade' => 0,
+            ];
+        }
+        return [
+            'room_id' => 'LSLIVE',
+            'status' => 'playing',
+            'seq' => 1,
+            'turn' => 3,
+            'phase' => 'live_start_effects',
+            'first_player' => 'p1',
+            'active_player' => 'p1',
+            'live_attempt' => ['p1', 'p2'],
+            'log' => [],
+            'players' => [
+                'p1' => [
+                    'id' => 'p1',
+                    'name' => 'Performer',
+                    'hand' => [],
+                    'stage' => [
+                        'left' => null,
+                        'center' => $this->bluffMember('p1c'),
+                        'right' => null,
+                    ],
+                    'waiting_room' => [],
+                    'energy_zone' => [],
+                    'energy_deck' => [],
+                    'main_deck' => $deck,
+                    'live_zone' => $p1Live,
+                    'success_lives' => [],
+                ],
+                'p2' => [
+                    'id' => 'p2',
+                    'name' => 'BluffOnly',
+                    'hand' => [],
+                    'stage' => [
+                        'left' => null,
+                        'center' => $p2Center,
+                        'right' => null,
+                    ],
+                    'waiting_room' => [],
+                    'energy_zone' => [],
+                    'energy_deck' => [],
+                    'main_deck' => $deck,
+                    'live_zone' => $p2Live,
+                    'success_lives' => [],
+                ],
+            ],
+        ];
+    }
+
+    public function testMemberBluffOnlySeatSkipsStageLiveStart(): void
+    {
+        $kaho = $this->kahoWithBlades();
+        $state = $this->baseState(
+            [$this->plainLive('p1live')],
+            [$this->bluffMember('p2bluff')],
+            $kaho
+        );
+
+        $this->assertTrue(\playerParticipatingInLiveRound($state, 'p2'));
+        $this->assertFalse(\playerAttemptingLivePerformance($state, 'p2'));
+
+        $handBefore = count($state['players']['p2']['hand']);
+        $deckBefore = count($state['players']['p2']['main_deck']);
+        $wrBefore = count($state['players']['p2']['waiting_room']);
+
+        $state = \resolveLiveStartAbilities($state, 'p2');
+
+        $this->assertNull($state['pending_prompt'] ?? null);
+        $this->assertSame($handBefore, count($state['players']['p2']['hand']));
+        $this->assertSame($deckBefore, count($state['players']['p2']['main_deck']));
+        $this->assertSame($wrBefore, count($state['players']['p2']['waiting_room']));
+        $this->assertSame([], \collectOptionalLiveStartAbilities($state));
+    }
+
+    public function testLivePerformerStillGetsStageLiveStart(): void
+    {
+        $kaho = $this->kahoWithBlades();
+        // Swap: p2 has the Live + Kaho; p1 only a bluff.
+        $state = $this->baseState(
+            [$this->bluffMember('p1bluff')],
+            [$this->plainLive('p2live')],
+            $kaho
+        );
+        $state['live_attempt'] = ['p2', 'p1'];
+        $state['_live_start_perf_pid'] = 'p2';
+
+        $this->assertTrue(\playerAttemptingLivePerformance($state, 'p2'));
+
+        $deckBefore = count($state['players']['p2']['main_deck']);
+        $state = \resolveLiveStartAbilities($state, 'p2');
+
+        // Kaho Live Start: draw 2 then mandatory discard 1 (prompt or applied).
+        $drewOrPrompted = !empty($state['pending_prompt'])
+            || count($state['players']['p2']['main_deck']) < $deckBefore
+            || count($state['players']['p2']['hand']) > 0
+            || count($state['players']['p2']['waiting_room']) > 0;
+        $this->assertTrue($drewOrPrompted, 'Performing player must still resolve Kaho Live Start');
+    }
+
+    public function testBeginLiveStartForPerformerSkipsBluffOnly(): void
+    {
+        $kaho = $this->kahoWithBlades();
+        $state = $this->baseState(
+            [$this->plainLive('p1live')],
+            [$this->bluffMember('p2bluff')],
+            $kaho
+        );
+        $state['live_show'] = [
+            'turn' => 3,
+            'stage' => 'performance',
+            'performer' => 'p2',
+            'started_at' => time(),
+            'stage_seq' => 2,
+            'acks' => [],
+            'played_lives' => ['p1' => ['p1live'], 'p2' => []],
+        ];
+        $state['_live_start_done'] = ['p1' => true];
+
+        $handBefore = count($state['players']['p2']['hand']);
+        $state = \beginLiveStartForPerformer($state, 'p2');
+
+        $this->assertNull($state['pending_prompt'] ?? null);
+        $this->assertSame($handBefore, count($state['players']['p2']['hand']));
+        $log = implode("\n", array_map(
+            static fn($e) => is_array($e) ? (string)($e['msg'] ?? '') : (string)$e,
+            $state['log'] ?? []
+        ));
+        $this->assertStringNotContainsString('Live Start Effects (BluffOnly)', $log);
+    }
+
+    public function testEmptyStorageStillAllowsIsolatedLiveStartSkillTests(): void
+    {
+        $kaho = $this->kahoWithBlades();
+        $state = $this->baseState([], [], $kaho);
+        $state['live_attempt'] = ['p2'];
+        $deckBefore = count($state['players']['p2']['main_deck']);
+        $state = \resolveLiveStartAbilities($state, 'p2');
+        $drewOrPrompted = !empty($state['pending_prompt'])
+            || count($state['players']['p2']['main_deck']) < $deckBefore
+            || count($state['players']['p2']['hand']) > 0;
+        $this->assertTrue($drewOrPrompted, 'Empty live_zone must not block isolated Live Start tests');
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Stage **[Live Start]** skills (e.g. Kaho Hinoshita `PL!HS-pb1-009` blade draw/discard) could fire for a player who only set **Member bluffs** in Live storage while the opponent was performing Lives.

## Fix
- Add `playerShouldResolveLiveStart()` — if Live storage has cards but none are Live-type, skip Live Start
- Gate `resolveLiveStartAbilities`, `collectOptionalLiveStartAbilities`, and `beginLiveStartForPerformer`
- Empty storage still allowed so isolated skill unit tests keep working (real empty seats are already out of `live_attempt`)

## Tests
`./vendor/bin/phpunit --filter LiveStartRequiresLiveCardsTest` (4 passing)

## CI note
`verify` is red with the same **18 failures / 2 errors** already on `main` (e.g. StellarStream order prompt, Eutopia score). This PR does not add those failures; suite size is main+4 for the new regression tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f7a788-4ce6-4d6a-9b94-3761fe02d5e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

